### PR TITLE
add plan backend (model + api)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,8 @@ from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from flask_restful import Api
 from resources.login import Login
+from resources.plan import PlanAPI
+from resources.user import UserAPI
 from dotenv import load_dotenv
 import time
 import os
@@ -18,7 +20,8 @@ api = Api(app)
 CORS(app)
 
 api.add_resource(Login, '/api/login')
-
+api.add_resource(PlanAPI, '/api/plan','/api/plan/<string:id>')
+api.add_resource(UserAPI, '/api/user','/api/user/<string:uuid>')
 @app.route('/')
 def index():
     return jsonify({'message': 'Hello, World!'})

--- a/backend/exceptions/plan_errors.py
+++ b/backend/exceptions/plan_errors.py
@@ -1,0 +1,22 @@
+import json
+
+
+class PlanNotFoundError(Exception):
+    def __init__(self, id: str):
+        self.message = f"Plan with id {id} not found in db"
+        super().__init__(self.message)
+
+
+class PlanCreationError(Exception):
+    def __init__(self, data: dict):
+        try:
+            self.message = f'Could not create plan obj using the following dict: {json.dumps(data)}'
+        except:
+            self.message = 'Could not create plan obj using the provided dict'
+        super().__init__(self.message)
+
+
+class PlanDBAddingError(Exception):
+    def __init__(self):
+        self.message = 'could not add the following plan into the db'
+        super().__init__(self.message)

--- a/backend/exceptions/plan_errors.py
+++ b/backend/exceptions/plan_errors.py
@@ -18,5 +18,5 @@ class PlanCreationError(Exception):
 
 class PlanDBAddingError(Exception):
     def __init__(self):
-        self.message = 'could not add the following plan into the db'
+        self.message = 'Could not add the following plan into the db'
         super().__init__(self.message)

--- a/backend/exceptions/user_errors.py
+++ b/backend/exceptions/user_errors.py
@@ -1,0 +1,24 @@
+import json
+
+
+# parent class for user errors?
+# we're overriding original error data!! should not do that
+class UserNotFoundError(Exception):
+    def __init__(self, id: str):
+        self.message = f"User with id {id} not found in db"
+        super().__init__(self.message)
+
+
+class UserCreationError(Exception):
+    def __init__(self, data: {}):
+        try:
+            self.message = f'Could not create user obj using the following dict: {json.dumps(data)}'
+        except:
+            self.message = 'Could not create user obj using the provided dict'
+        super().__init__(self.message)
+
+
+class UserDBAddingError(Exception):
+    def __init__(self, user):
+        self.message = f'could not add the following user into the db:\n{json.dumps(user.json())}'
+        super().__init__(self.message)

--- a/backend/models/plan.py
+++ b/backend/models/plan.py
@@ -1,4 +1,118 @@
-class plan:
+import datetime
 
-    def __init__(self, name:str, description:str):
-        pass
+from db import db
+from models.user import User
+from exceptions.plan_errors import PlanCreationError, PlanNotFoundError, PlanDBAddingError
+#from google.cloud import firestore
+
+
+class Plan:
+    def __init__(self, name: str, description: str, date: datetime, location: str, admin: User,
+                 participants: list[User], uid: str):
+        self.uid = uid
+        self.name = name
+        self.description = description
+        self.admin: User = admin  # aka the creator
+        self.date: datetime = date
+        self.location: str = location
+        self.participants: list[User] = [admin] if participants is None else participants
+
+    def json(self):
+        return {
+            'id': self.uid,
+            'name': self.name,
+            'description': self.description,
+            'date': self.date.strftime('%d/%m/%Y'),
+            'location': self.location,
+            #'admin': self.admin.json(),
+            'admin': self.admin,
+            'participants': self.participants
+            #'participants': [p.json() for p in self.participants]
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict, include_uid=True):
+        try:
+            if include_uid:
+                return Plan(d[u'name'], d[u'description'], d[u'date'], d[u'location'], d[u'admin'], d[u'participants'],
+                            d[u'uid'])
+            return Plan(d[u'name'], d[u'description'], d[u'date'], d[u'location'], d[u'admin'], d[u'participants'],
+                        None)
+        except Exception as e:
+            raise PlanCreationError(d) from e
+
+    def add_plan(self):
+        try:
+            update_time, us_ref = db.collection(u'plans').add({
+                u'name': self.name,
+                u'description': self.description,
+                u'date': self.date,
+                u'location': self.location,
+                u'admin': self.admin.uuid if isinstance(self.admin, User) else self.admin,
+                u'participants': [p.uuid for p in self.participants] if isinstance(self.participants[0],
+                                                                                   User) else self.participants
+            })
+            self.uid = us_ref.id
+        except Exception as e:
+            raise PlanDBAddingError() from e
+
+    def update_plan(self):
+        try:
+            p_ref = db.collection(u'plans').document(self.uid)
+            p_ref.set({
+                u'name': self.name,
+                u'description': self.description,
+                u'date': self.date,
+                u'location': self.location,
+                u'admin': self.admin.uuid if isinstance(self.admin, User) else self.admin,
+                u'participants': [p.uuid for p in self.participants] if isinstance(self.participants[0],
+                                                                                   User) else self.participants
+            }, merge=True)
+            self.uid = p_ref.id
+        except Exception as e:
+            raise PlanDBAddingError() from e
+    @classmethod
+    def get_plan_by_id(cls, id: str):
+        p = db.collection(u'plans').document(id).get().to_dict()
+        if p is None:
+            raise PlanNotFoundError(id)
+        p['uid'] = id
+        try:
+            return Plan.from_dict(p)
+        except Exception as e:
+            raise PlanCreationError(p) from e
+
+    """
+    def add_participant(self, uuid: str):
+        user = User.get_user(uuid)
+        self.participants.append(user)
+        ref = db.collection(u'plans').document(self.uid)
+        ref.update({u'participants': firestore.ArrayUnion([uuid])})
+
+    def remove_participant(self, uuid: str):
+        if uuid in self.participants:
+            ref = db.collection(u'plans').document(self.uid)
+            ref.update({u'participants': firestore.ArrayUnion([uuid])})
+    """
+
+    """
+    @classmethod
+    def get_user_plans(self, uuid:str) -> [Plan]:
+        query = (db.collection(u'plans')
+                 .where(filter=FieldFilter("participants", "array-contains", uuid))).stream()
+        # if query.exists():
+            raise 'algo'
+        plans = []
+        for q in query:
+            try:
+                aux = q.to_dict()
+                aux['uid'] = q.id
+                plans.append(aux)
+            except Exception as e:
+                continue
+        if len(plans) == 0:
+            raise PlanCreationError({})
+
+        self.plans = plans
+        return plans
+    """

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,38 +1,51 @@
+import json
+
 from db import db
 import datetime
+from exceptions.user_errors import UserNotFoundError, UserCreationError, UserDBAddingError
+from google.cloud.firestore_v1.base_query import FieldFilter
 
 
 class User:
     """
     Class that defines user model in firestore db and interacts with it
     """
+
     def __init__(self, username: str, uuid: str = None, joined: datetime = None):
         self.username: str = username
         self.uuid: str = uuid
         self.joined: datetime = joined if joined is not None else datetime.datetime.now(tz=datetime.timezone.utc)
+        #self.plans: [Plan] = None
 
     @classmethod
     def from_dict(cls, d: dict):
         return User(username=d['username'], uuid=d['uuid'], joined=d['joined'])
 
-    def json(self):
-        return {
+    def json(self, return_plans=False) -> dict:
+        d = {
             'username': self.username,
             'uuid': self.uuid,
             'joined': self.joined.strftime("%d/%m/%Y")
         }
+        if return_plans:
+            d['plans'] = [p.json() for p in self.get_user_plans()]
+
+        return d
 
     def add_user(self):
-        update_time, us_ref = db.collection(u'users').add({u'username': self.username, u'joined': self.joined})
-        self.uuid = us_ref.id
+        try:
+            update_time, us_ref = db.collection(u'users').add({u'username': self.username, u'joined': self.joined})
+            self.uuid = us_ref.id
+        except Exception as e:
+            raise UserDBAddingError() from e
 
     @classmethod
     def get_user(cls, uuid: str):
         u = db.collection(u'users').document(uuid).get().to_dict()
         if u is None:
-            raise f'could not fetch data for user {uuid}'
+            raise UserNotFoundError(uuid)
         u['uuid'] = uuid
         try:
             return User.from_dict(u)
         except Exception as e:
-            raise f"could not instantiate user obj from fetched dict: {u}.\nError: {e}"
+            raise UserCreationError(u) from e

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
-cryptography>=41.0.6
+cryptography==41.0.7
 firebase-admin==6.2.0
 Flask==3.0.0
 Flask-Cors==4.0.0

--- a/backend/resources/login.py
+++ b/backend/resources/login.py
@@ -5,17 +5,6 @@ from flask import jsonify, make_response
 
 
 class Login(Resource):
-    @jwt_required()
-    def get(self):
-        """
-        :return: json with user data
-        """
-        uuid = get_jwt_identity()
-        try:
-            return jsonify(User.get_user(uuid).json())
-        except Exception as e:
-            return {"Error": "could not get user data"}, 403
-
     def post(self):
         """
         Function that

--- a/backend/resources/plan.py
+++ b/backend/resources/plan.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+
+from flask import jsonify
+from flask_restful import Resource, reqparse
+from models.plan import Plan
+from models.user import User
+from exceptions.plan_errors import PlanCreationError, PlanNotFoundError, PlanDBAddingError
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+
+class PlanAPI(Resource):
+    @jwt_required()
+    def get(self, id):
+        try:
+            return jsonify(Plan.get_plan_by_id(id).json())
+        except PlanNotFoundError as e:
+            return {'message': e.message}, 404
+        except PlanCreationError as e:
+            return {'message': e.message}, 400
+        except Exception as e:
+            return {'message': f'could not retrieve plan with id {id}'}, 400
+
+    @jwt_required()
+    def post(self):
+
+        parser = reqparse.RequestParser()
+        parser.add_argument('name', type=str, required=True)
+        parser.add_argument('description', type=str, required=True)
+        parser.add_argument('date', type=lambda x: datetime.strptime(x, '%d/%m/%Y'), required=True)
+        parser.add_argument('location', type=str, required=True)
+        p = parser.parse_args()
+
+        uuid = get_jwt_identity()
+        p['admin'] = uuid
+        p['participants'] = [uuid]
+
+        try:
+            plan = Plan.from_dict(p, include_uid=False)
+            plan.add_plan()
+            return jsonify(plan.json())
+        except PlanCreationError as e:
+            return {'message': e.message}, 400
+        except PlanDBAddingError as e:
+            return {'message': e.message}, 404
+        except Exception as e:
+            return {'message': 'error creating the plan'}, 500
+
+
+    @jwt_required()
+    def put(self, id):
+        try:
+            pl = Plan.get_plan_by_id(id)
+        except PlanNotFoundError as e:
+            return {'message': e.message}, 404
+        except PlanCreationError as e:
+            return {'message': e.message}, 400
+        except Exception as e:
+            return {'message': f'could not retrieve plan with id {id}'}, 400
+
+        parser = reqparse.RequestParser()
+        parser.add_argument('name', type=str, required=True)
+        parser.add_argument('description', type=str, required=True)
+        parser.add_argument('date', type=lambda x: datetime.strptime(x, '%d/%m/%Y'), required=True)
+        parser.add_argument('location', type=str, required=True)
+        parser.add_argument('admin', type=str, required=True)
+        p = parser.parse_args()
+
+        if pl.name != p['name']:
+            pl.name = p['name']
+        if pl.description != p['description']:
+            pl.description = p['description']
+        if pl.date != p['date']:
+            pl.date = p['date']
+        if pl.location != p['location']:
+            pl.location = p['location']
+        if pl.admin != p['admin']:
+            try:
+                User.get_user(p['admin'])
+                pl.admin = p['admin']
+            except Exception as e:
+                return {'message':f'the admin value {p["admin"]} is not a valid user id'}
+
+        try:
+            pl.update_plan()
+            return jsonify(pl.json())
+        except PlanDBAddingError as e:
+            return {'message': e.message}, 404
+        except Exception as e:
+            return {'message': 'error updating the plan'}, 500
+

--- a/backend/resources/user.py
+++ b/backend/resources/user.py
@@ -1,0 +1,38 @@
+from flask import jsonify
+from flask_restful import Resource, reqparse
+from exceptions.user_errors import UserCreationError, UserNotFoundError
+from models.user import User
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+
+class UserAPI(Resource):
+    @jwt_required()
+    def get(self, uuid=None):
+        uuid = uuid if uuid is not None else get_jwt_identity()
+        try:
+            return jsonify(User.get_user(uuid).json())
+        except UserNotFoundError as e:
+            return {'message': e.message}, 404
+        except UserCreationError as e:
+            return {'message': e.message}, 400
+        except Exception as e:
+            return {'message': f'could not retrieve plan with id {id}'}, 400
+
+    @jwt_required()
+    def put(self):
+        # update username
+        parser = reqparse.RequestParser()
+        parser.add_argument('username', type=str, required=True)
+        data = parser.parse_args()
+
+        uuid = get_jwt_identity()
+        try:
+            u = User.get_user(uuid)
+            u.username = data['username']
+            u.add_user()
+            return jsonify(u.json())
+        except UserNotFoundError as e:
+            return {'message': e.message}, 404
+        except UserCreationError as e:
+            return {'message': e.message}, 400
+


### PR DESCRIPTION
closes issue #20 
Some required endpoints have not been created yet such as delete plan or ~~delete user~~ or get all plans from one user.

Endpoints created so far:

- /api/login 
-- POST : Creates user 
- /api/plan
-- POST: Creates new plan
- /api/plan/<string:id>
-- GET: returns id matching plan
-- PUT: updates plan. All fields have to be sent.
- /api/user:
-- GET: returns your user data
-- PUT: updates user
- /api/user/<string:uuid>:
-- GET: returns user that matches with uuid
-- PUT: update user. only username filed have to be provided

⚠️ config option JWT_COOKIE_CSRF_PROTECT is enabled by default (i can change it) and it requires to add X-CSRF-TOKEN header to every request with body