### PR TITLE
Add lint and format to npm commands

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,7 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:react/jsx-runtime',
     'plugin:react-hooks/recommended',
+    "plugin:oxlint/recommended",
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,5 @@
+import oxlint from "eslint-plugin-oxlint";
+
+export default [
+  oxlint.configs["flat/recommended"], // oxlint should be the last one
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
         "@vitejs/plugin-react": "^4.0.3",
         "autoprefixer": "^10.4.16",
         "eslint": "^8.45.0",
+        "eslint-plugin-oxlint": "^0.2.3",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
         "oxlint": "^0.1.2",
         "postcss": "^8.4.31",
+        "prettier": "^3.2.5",
         "tailwindcss": "^3.3.5",
         "vite": "^4.5.2"
       }
@@ -2040,6 +2042,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-plugin-oxlint": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-0.2.3.tgz",
+      "integrity": "sha512-Grdd+CmeyDxJAar251bh4n9CYZh/3uc0wIc7rrtaRgq7wFibM2oikpzGvA5QDM7/Yvnw/brajWGbIJlLK7pBGA==",
+      "dev": true
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.33.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
@@ -3929,6 +3937,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "npx oxlint && npx eslint",
     "preview": "vite preview",
-    "start-api": "cd backend && venv/bin/flask run --no-debugger"
+    "start-api": "cd backend && venv/bin/flask run --no-debugger",
+    "format": "prettier --write 'src/**/*.{js,jsx}'"
   },
   "dependencies": {
     "axios": "^1.6.3",
@@ -24,11 +25,13 @@
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.45.0",
+    "eslint-plugin-oxlint": "^0.2.3",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "oxlint": "^0.1.2",
     "postcss": "^8.4.31",
+    "prettier": "^3.2.5",
     "tailwindcss": "^3.3.5",
     "vite": "^4.5.2"
   }


### PR DESCRIPTION
For running the linter we can run: 
```sh
npm run lint
```
And to format the files we can run:
```sh
npm run format
```
This use `Prettier`.