### PR TITLE
Endpoint connection 2

### DIFF
--- a/src/components/plan/PlanForm.jsx
+++ b/src/components/plan/PlanForm.jsx
@@ -109,7 +109,7 @@ const PlanForm = () => {
     };
 
     const handleClear = () => {
-        resetForm(true);
+        resetForm();
         toast.info("Form cleared");
     };
 

--- a/src/components/plan/PlanForm.jsx
+++ b/src/components/plan/PlanForm.jsx
@@ -4,7 +4,7 @@ import Input from "../form/Input";
 import Button from "../Button";
 import { toast } from "react-toastify";
 import BigInput from "../form/BigInput";
-import {createPlan, getUserData, updateUsername} from "../../comutils";
+import { createPlan, getUserData, updateUsername } from "../../comutils";
 import LoadingView from "../loader/LoadingView";
 
 const PlanForm = () => {
@@ -17,7 +17,7 @@ const PlanForm = () => {
     const [description, setDescription] = useState("");
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(true);
-    const [username, setUsername] = useState("")
+    const [username, setUsername] = useState("");
 
     useEffect(() => {
         const savedState = localStorage.getItem("planFormState");
@@ -29,14 +29,16 @@ const PlanForm = () => {
             setLocation(parsedState.location);
             setDescription(parsedState.description);
         }
-        getUserData().then(r => {
-            if (r.data.username){
-                setUsername(r.data.username)
-                setAuthor(r.data.username)
-            }
-        }).catch(e => {
-            console.log('could not fetch user data' + e)
-        })
+        getUserData()
+            .then((r) => {
+                if (r.data.username) {
+                    setUsername(r.data.username);
+                    setAuthor(r.data.username);
+                }
+            })
+            .catch((e) => {
+                console.log("could not fetch user data" + e);
+            });
         setLoading(false);
     }, []);
 
@@ -64,27 +66,27 @@ const PlanForm = () => {
         const formattedDate = formatDate(date);
 
         // Call the update username enpoint
-        updateUsername(author).then(r => {
-            // Call the post endpoint
-            createPlan(title, description, formattedDate, location)
-                .then((r) => {
-                    //resetForm();
-                    //setLoading(false);
-                    toast.success("Plan created successfully");
-                    navigate(`/plan/${r.data.id}`);
-                })
-                .catch((error) => {
-                    setLoading(false);
-                    console.error("Error creating plan:", error);
-                    toast.error("Error creating plan. Please try again.");
-                });
-        })
-        .catch((error) => {
-            setLoading(false);
-            console.error("Error updating username (prior to plan creation):", error);
-            toast.error("Error creating plan. Please try again.");
-
-        })
+        updateUsername(author)
+            .then((r) => {
+                // Call the post endpoint
+                createPlan(title, description, formattedDate, location)
+                    .then((r) => {
+                        //resetForm();
+                        //setLoading(false);
+                        toast.success("Plan created successfully");
+                        navigate(`/plan/${r.data.id}`);
+                    })
+                    .catch((error) => {
+                        setLoading(false);
+                        console.error("Error creating plan:", error);
+                        toast.error("Error creating plan. Please try again.");
+                    });
+            })
+            .catch((error) => {
+                setLoading(false);
+                console.error("Error updating username (prior to plan creation):", error);
+                toast.error("Error creating plan. Please try again.");
+            });
     };
 
     // Function to format the date
@@ -103,7 +105,7 @@ const PlanForm = () => {
         setLocation("");
         setDescription("");
         setError("");
-        setAuthor(username)
+        setAuthor(username);
     };
 
     const handleClear = () => {


### PR DESCRIPTION
changelog:
- creators can also change their username when creating a plan.
- if they have, their username appears in the form (can be changed but is not erased when pressing the clear button).

i have nested the calls for update username + plan creation (if the username update fails, the plan won't be created). It can also be done separately (if the first call fails, the plan will have the chance to be created)