### PR TITLE
Increase description length

### DIFF
--- a/backend/resources/plan.py
+++ b/backend/resources/plan.py
@@ -48,6 +48,8 @@ class PlanAPI(Resource):
         p['admin'] = uuid
         p['participants'] = [uuid]
 
+        if len(p['description']) > 5000:
+            return {'message': 'Description cannot be longer than 5000 characters'}, 400
         try:
             plan = Plan.from_dict(p)
             plan.add_plan()

--- a/backend/tests/functional/test_plan.py
+++ b/backend/tests/functional/test_plan.py
@@ -58,6 +58,7 @@ def test_create_plan(client, sample_user):
     retrieved_plan = Plan.get_plan_by_id(response_data['id'])
     retrieved_plan.delete_plan()
 
+
 def test_create_plan_bigger_than_5000(client, sample_user):
     """
     Test creating a new plan with a description bigger than 5000 characters.
@@ -82,6 +83,7 @@ def test_create_plan_bigger_than_5000(client, sample_user):
     response_data = json.loads(res.get_data(as_text=True))
     assert 'message' in response_data
     assert response_data['message'] == 'Description cannot be longer than 5000 characters'
+
 
 def test_update_plan(client, sample_user, sample_plan):
     """

--- a/src/components/plan/PlanForm.jsx
+++ b/src/components/plan/PlanForm.jsx
@@ -179,7 +179,7 @@ const PlanForm = () => {
                                     onChange={setDescription}
                                     value={description}
                                     error={error && !description}
-                                    maxLength={250}
+                                    maxLength={5000}
                                 />
                             </div>
 


### PR DESCRIPTION
Description can now be longer, up to `5000` characters. 
Added a limit in the backend and a test to check it.